### PR TITLE
Support for safe 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.4 || ^8.0",
         "ext-simplexml": "*",
         "vimeo/psalm": "^4.0",
-        "thecodingmachine/safe": "^1.1"
+        "thecodingmachine/safe": "^1.1|^2.1"
     },
     "license": "MIT",
     "authors": [

--- a/psalm-test.xml
+++ b/psalm-test.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
     errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Hi, @hectorj,

this solves #16. This seems to work without further required changes.

In `psalm-test.xml` the attribute `totallyTyped` was deprecated and I removed it, so the tests should get green here.

Do you have some additions or can we get this merged?